### PR TITLE
Generate product number automatically

### DIFF
--- a/sahibinden/ecommerce_app/models.py
+++ b/sahibinden/ecommerce_app/models.py
@@ -12,3 +12,17 @@ class Product(models.Model):
 
     def __str__(self):
         return self.name
+
+    def save(self, *args, **kwargs):
+        if not self.product_no:
+            last_product = Product.objects.all().order_by('product_no').last()
+            if last_product:
+                last_product_no = int(last_product.product_no[1:]) + 1
+                self.product_no = f"P{last_product_no:03d}"
+            else:
+                self.product_no = "P001"
+        super().save(*args, **kwargs)
+
+    def __str__(self):
+        return self.name
+# to generate product number automatically 


### PR DESCRIPTION
Created the function to generate product number automatically.


I  override the `save()` method in your `Product` model to automatically generate the product number. 


> . If it's a new product (i.e., `product_no` is empty), I retrieve the last product with a generated product number, increment the number by 1, and format it as "PXXX".

> . If there are no existing  products with generated product numbers, I set the product number to "P001".

With this implementation, every time you create a new `Product` instance, it will automatically generate a unique product number 